### PR TITLE
Fixes #55: bug when data is a tibble

### DIFF
--- a/R/mjoint.R
+++ b/R/mjoint.R
@@ -26,7 +26,8 @@
 #'   multiple longitudinal outcomes with different measurement protocols. If the
 #'   multiple longitudinal outcomes are measured at the same time points for
 #'   each patient, then a \code{data.frame} object can be given instead of a
-#'   \code{list}. It is assumed that each data frame is in long format.
+#'   \code{list}. It is assumed that each data frame is in long format. \code{tibble}
+#'   objects are automatically converted to plain \code{data.frame} objects.
 #' @param survData a \code{data.frame} in which to interpret the variables named
 #'   in the \code{formSurv}. This is optional, and if not given, the required
 #'   data is searched for in \code{data}. Default is \code{survData=NULL}.
@@ -363,6 +364,15 @@ mjoint <- function(formLongFixed, formLongRandom, formSurv, data, survData = NUL
   if (length(data) != K) {
     stop(paste("The number of datasets expected is K =", K))
   }
+
+  # Strip `tibble` class from data (breaks indexing by column) if present
+  data <- lapply(data, function(d) {
+    if (any(c("tbl_df", "tbl") %in% class(d))) {
+      return(as.data.frame(d))
+    } else {
+      return(d)
+    }
+  })
 
   id <- as.character(nlme::splitFormula(formLongRandom[[1]], "|")[[2]])[2]
   n <- length(unique(data[[1]][, id]))

--- a/R/mjoint.R
+++ b/R/mjoint.R
@@ -349,7 +349,7 @@ mjoint <- function(formLongFixed, formLongRandom, formSurv, data, survData = NUL
 
   # Data does not need to a list if K=1
   # if K>1 and not a list, assume data balanced
-  if (class(data) != "list") {
+  if (!("list" %in% class(data))) {
     balanced <- TRUE
     data <- list(data)
     if (K > 1) {

--- a/README.Rmd
+++ b/README.Rmd
@@ -22,12 +22,6 @@ knitr::opts_chunk$set(
 [![](https://cranlogs.r-pkg.org/badges/grand-total/joineRML)](https://CRAN.R-project.org/package=joineRML)
 [![codecov](https://codecov.io/gh/graemeleehickey/joineRML/branch/master/graph/badge.svg)](https://codecov.io/gh/graemeleehickey/joineRML)
 
-Fork build status and code coverage:
-
-[![Travis-CI Build Status](https://travis-ci.org/ellessenne/joineRML.svg?branch=master)](https://travis-ci.org/ellessenne/joineRML)
-[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/ellessenne/joineRML?branch=master&svg=true)](https://ci.appveyor.com/project/ellessenne/joineRML)
-[![codecov](https://codecov.io/gh/ellessenne/joineRML/branch/master/graph/badge.svg)](https://codecov.io/gh/ellessenne/joineRML)
-
 `joineRML` is an extension of the joineR package for fitting joint models of time-to-event data and multivariate longitudinal data. The model fitted in joineRML is an extension of the Wulfsohn and Tsiatis (1997) and Henderson et al. (2000) models, which is comprised on $(K+1)$-sub-models: a Cox proportional hazards regression model (Cox, 1972) and a $K$-variate linear mixed-effects model - a direct extension of the Laird and Ware (1982) regression model. The model is fitted using a Monte Carlo Expectation-Maximization (MCEM) algorithm, which closely follows the methodology presented by Lin et al. (2002).
 
 ## Why use joineRML?

--- a/README.Rmd
+++ b/README.Rmd
@@ -12,7 +12,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-# joineRML <img src="man/figures/hex.png" width = "175" height = "200" align="right" /> 
+# joineRML <img src="man/figures/hex.png" width = "175" height = "200" align="right" />
 
 [![Travis-CI Build Status](https://travis-ci.org/graemeleehickey/joineRML.svg?branch=master)](https://travis-ci.org/graemeleehickey/joineRML)
 [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/graemeleehickey/joineRML?branch=master&svg=true)](https://ci.appveyor.com/project/graemeleehickey/joineRML)
@@ -21,6 +21,12 @@ knitr::opts_chunk$set(
 [![](http://cranlogs.r-pkg.org/badges/joineRML)](https://CRAN.R-project.org/package=joineRML)
 [![](https://cranlogs.r-pkg.org/badges/grand-total/joineRML)](https://CRAN.R-project.org/package=joineRML)
 [![codecov](https://codecov.io/gh/graemeleehickey/joineRML/branch/master/graph/badge.svg)](https://codecov.io/gh/graemeleehickey/joineRML)
+
+Fork build status and code coverage:
+
+[![Travis-CI Build Status](https://travis-ci.org/ellessenne/joineRML.svg?branch=master)](https://travis-ci.org/ellessenne/joineRML)
+[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/ellessenne/joineRML?branch=master&svg=true)](https://ci.appveyor.com/project/ellessenne/joineRML)
+[![codecov](https://codecov.io/gh/ellessenne/joineRML/branch/master/graph/badge.svg)](https://codecov.io/gh/ellessenne/joineRML)
 
 `joineRML` is an extension of the joineR package for fitting joint models of time-to-event data and multivariate longitudinal data. The model fitted in joineRML is an extension of the Wulfsohn and Tsiatis (1997) and Henderson et al. (2000) models, which is comprised on $(K+1)$-sub-models: a Cox proportional hazards regression model (Cox, 1972) and a $K$-variate linear mixed-effects model - a direct extension of the Laird and Ware (1982) regression model. The model is fitted using a Monte Carlo Expectation-Maximization (MCEM) algorithm, which closely follows the methodology presented by Lin et al. (2002).
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,6 @@ joineRML <img src="man/figures/hex.png" width = "175" height = "200" align="righ
 
 [![Travis-CI Build Status](https://travis-ci.org/graemeleehickey/joineRML.svg?branch=master)](https://travis-ci.org/graemeleehickey/joineRML) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/graemeleehickey/joineRML?branch=master&svg=true)](https://ci.appveyor.com/project/graemeleehickey/joineRML) <!--[![License](https://img.shields.io/badge/License-GPL%20%28%3E=%203%29-brightgreen.svg)](http://www.gnu.org/licenses/gpl-3.0.html)--> [![CRAN\_Status\_Badge](http://www.r-pkg.org/badges/version/joineRML)](https://CRAN.R-project.org/package=joineRML) [![](http://cranlogs.r-pkg.org/badges/joineRML)](https://CRAN.R-project.org/package=joineRML) [![](https://cranlogs.r-pkg.org/badges/grand-total/joineRML)](https://CRAN.R-project.org/package=joineRML) [![codecov](https://codecov.io/gh/graemeleehickey/joineRML/branch/master/graph/badge.svg)](https://codecov.io/gh/graemeleehickey/joineRML)
 
-Fork build status and code coverage:
-
-[![Travis-CI Build Status](https://travis-ci.org/ellessenne/joineRML.svg?branch=master)](https://travis-ci.org/ellessenne/joineRML) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/ellessenne/joineRML?branch=master&svg=true)](https://ci.appveyor.com/project/ellessenne/joineRML) [![codecov](https://codecov.io/gh/ellessenne/joineRML/branch/master/graph/badge.svg)](https://codecov.io/gh/ellessenne/joineRML)
-
 `joineRML` is an extension of the joineR package for fitting joint models of time-to-event data and multivariate longitudinal data. The model fitted in joineRML is an extension of the Wulfsohn and Tsiatis (1997) and Henderson et al. (2000) models, which is comprised on (*K* + 1)-sub-models: a Cox proportional hazards regression model (Cox, 1972) and a *K*-variate linear mixed-effects model - a direct extension of the Laird and Ware (1982) regression model. The model is fitted using a Monte Carlo Expectation-Maximization (MCEM) algorithm, which closely follows the methodology presented by Lin et al. (2002).
 
 Why use joineRML?

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ joineRML <img src="man/figures/hex.png" width = "175" height = "200" align="righ
 
 [![Travis-CI Build Status](https://travis-ci.org/graemeleehickey/joineRML.svg?branch=master)](https://travis-ci.org/graemeleehickey/joineRML) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/graemeleehickey/joineRML?branch=master&svg=true)](https://ci.appveyor.com/project/graemeleehickey/joineRML) <!--[![License](https://img.shields.io/badge/License-GPL%20%28%3E=%203%29-brightgreen.svg)](http://www.gnu.org/licenses/gpl-3.0.html)--> [![CRAN\_Status\_Badge](http://www.r-pkg.org/badges/version/joineRML)](https://CRAN.R-project.org/package=joineRML) [![](http://cranlogs.r-pkg.org/badges/joineRML)](https://CRAN.R-project.org/package=joineRML) [![](https://cranlogs.r-pkg.org/badges/grand-total/joineRML)](https://CRAN.R-project.org/package=joineRML) [![codecov](https://codecov.io/gh/graemeleehickey/joineRML/branch/master/graph/badge.svg)](https://codecov.io/gh/graemeleehickey/joineRML)
 
+Fork build status and code coverage:
+
+[![Travis-CI Build Status](https://travis-ci.org/ellessenne/joineRML.svg?branch=master)](https://travis-ci.org/ellessenne/joineRML) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/ellessenne/joineRML?branch=master&svg=true)](https://ci.appveyor.com/project/ellessenne/joineRML) [![codecov](https://codecov.io/gh/ellessenne/joineRML/branch/master/graph/badge.svg)](https://codecov.io/gh/ellessenne/joineRML)
+
 `joineRML` is an extension of the joineR package for fitting joint models of time-to-event data and multivariate longitudinal data. The model fitted in joineRML is an extension of the Wulfsohn and Tsiatis (1997) and Henderson et al. (2000) models, which is comprised on (*K* + 1)-sub-models: a Cox proportional hazards regression model (Cox, 1972) and a *K*-variate linear mixed-effects model - a direct extension of the Laird and Ware (1982) regression model. The model is fitted using a Monte Carlo Expectation-Maximization (MCEM) algorithm, which closely follows the methodology presented by Lin et al. (2002).
 
 Why use joineRML?

--- a/man/mjoint.Rd
+++ b/man/mjoint.Rd
@@ -29,7 +29,8 @@ in which to interpret the variables named in the \code{formLongFixed} and
 multiple longitudinal outcomes with different measurement protocols. If the
 multiple longitudinal outcomes are measured at the same time points for
 each patient, then a \code{data.frame} object can be given instead of a
-\code{list}. It is assumed that each data frame is in long format.}
+\code{list}. It is assumed that each data frame is in long format. \code{tibble}
+objects are automatically converted to plain \code{data.frame} objects.}
 
 \item{survData}{a \code{data.frame} in which to interpret the variables named
 in the \code{formSurv}. This is optional, and if not given, the required


### PR DESCRIPTION
Hi,
I added a quick fix for #55: when data is a `tibble`, it is automatically converted to a plain `data.frame` using `as.data.frame()`.
It should build fine: no problem on Travis CI (except with `R: oldrel`, where oddly enough it fails while installing the `nloptr` package, see [here](https://travis-ci.org/ellessenne/joineRML/jobs/279968619)) nor with Appveyor. Building the package, R CMD check, and the tests run fine on my machine locally.

I re-run the example from #55 and the example from the `mjoint()` help page using the heart valve data, and it works fine even using a `tibble` as input data.

I hope this helps! Cheers,

Alessandro