### PR TITLE
Added option for error-safe bootstrapping

### DIFF
--- a/R/bootSE.R
+++ b/R/bootSE.R
@@ -127,27 +127,23 @@ bootSE <- function(object, nboot = 100, ci = 0.95, use.mle = TRUE,
         # bootstrap sample data
         data.boot <- sampleData(object = object)
         # fit joint model
-        fit.boot <- tryCatch({
-          fit.boot <- suppressMessages(
-            mjoint(formLongFixed = formLongFixed,
-                   formLongRandom = formLongRandom,
-                   formSurv = formSurv,
-                   data = data.boot$longData.boot,
-                   survData = data.boot$survData.boot,
-                   timeVar = timeVar,
-                   inits = theta.hat,
-                   verbose = verbose,
-                   pfs = FALSE,
-                   control = con,
-                   ...))
-          return(fit.boot)
-        },
-        error = function(e) return(NULL))
+        fit.boot <- tryCatch(suppressMessages(
+          mjoint(formLongFixed = formLongFixed,
+                 formLongRandom = formLongRandom,
+                 formSurv = formSurv,
+                 data = data.boot$longData.boot,
+                 survData = data.boot$survData.boot,
+                 timeVar = timeVar,
+                 inits = theta.hat,
+                 verbose = verbose,
+                 pfs = FALSE,
+                 control = con,
+                 ...)),
+          error = function(e) NULL)
       }
       return(fit.boot)
     }} else {
       bootfun <- function() {
-        fit.boot <- NULL
         # bootstrap sample data
         data.boot <- sampleData(object = object)
         # fit joint model

--- a/R/bootSE.R
+++ b/R/bootSE.R
@@ -23,6 +23,7 @@
 #'   that if \code{ncores}>1, then \code{progress} is set to \code{FALSE} by
 #'   default, as it is not possible to display progress bars for parallel
 #'   processes at the current time.
+#' @param safe.boot logical: should each bootstrap replication be wrapped in a \code{\link[base]{tryCatch}} statement to catch errors (e.g. during the optimisation progress)? When model fitting throws errors, a new bootstrap sample is drawn for the current iteration and the model is re-fit; this process continue until a model fits succesfully. Default is \code{FALSE}.
 #' @inheritParams mjoint
 #'
 #' @details Standard errors and confidence intervals are obtained by repeated
@@ -84,7 +85,7 @@
 #' }
 bootSE <- function(object, nboot = 100, ci = 0.95, use.mle = TRUE,
                    verbose = FALSE, control = list(), progress = TRUE,
-                   ncores = 1, ...) {
+                   ncores = 1, safe.boot = FALSE, ...) {
 
   if (!inherits(object, "mjoint")) {
     stop("Use only with 'mjoint' model objects.\n")
@@ -118,25 +119,54 @@ bootSE <- function(object, nboot = 100, ci = 0.95, use.mle = TRUE,
   }
 
   # Internal function for bootstrap
-  bootfun <- function() {
-    # bootstrap sample data
-    data.boot <- sampleData(object = object)
-    # fit joint model
-    suppressMessages(
-      fit.boot <- mjoint(formLongFixed = formLongFixed,
-                         formLongRandom = formLongRandom,
-                         formSurv = formSurv,
-                         data = data.boot$longData.boot,
-                         survData = data.boot$survData.boot,
-                         timeVar = timeVar,
-                         inits = theta.hat,
-                         verbose = verbose,
-                         pfs = FALSE,
-                         control = con,
-                         ...)
-    )
-    return(fit.boot)
-  }
+  if (safe.boot) {
+    bootfun <- function() {
+      fit.boot <- NULL
+      # keep iterating if the model fails with errors
+      while (is.null(fit.boot)) {
+        # bootstrap sample data
+        data.boot <- sampleData(object = object)
+        # fit joint model
+        fit.boot <- tryCatch({
+          fit.boot <- suppressMessages(
+            mjoint(formLongFixed = formLongFixed,
+                   formLongRandom = formLongRandom,
+                   formSurv = formSurv,
+                   data = data.boot$longData.boot,
+                   survData = data.boot$survData.boot,
+                   timeVar = timeVar,
+                   inits = theta.hat,
+                   verbose = verbose,
+                   pfs = FALSE,
+                   control = con,
+                   ...))
+          return(fit.boot)
+        },
+        error = function(e) return(NULL))
+      }
+      return(fit.boot)
+    }} else {
+      bootfun <- function() {
+        fit.boot <- NULL
+        # bootstrap sample data
+        data.boot <- sampleData(object = object)
+        # fit joint model
+        fit.boot <- suppressMessages(
+          mjoint(formLongFixed = formLongFixed,
+                 formLongRandom = formLongRandom,
+                 formSurv = formSurv,
+                 data = data.boot$longData.boot,
+                 survData = data.boot$survData.boot,
+                 timeVar = timeVar,
+                 inits = theta.hat,
+                 verbose = verbose,
+                 pfs = FALSE,
+                 control = con,
+                 ...)
+        )
+        return(fit.boot)
+      }
+    }
 
   if (ncores > 1) {
     ncores.max <- parallel::detectCores()

--- a/man/bootSE.Rd
+++ b/man/bootSE.Rd
@@ -5,7 +5,7 @@
 \title{Standard errors via bootstrap for an \code{mjoint} object}
 \usage{
 bootSE(object, nboot = 100, ci = 0.95, use.mle = TRUE, verbose = FALSE,
-  control = list(), progress = TRUE, ncores = 1, ...)
+  control = list(), progress = TRUE, ncores = 1, safe.boot = FALSE, ...)
 }
 \arguments{
 \item{object}{an object inheriting from class \code{mjoint} for a joint model
@@ -114,6 +114,8 @@ function. By default, \code{ncores=1}, which defaults to serial mode. Note
 that if \code{ncores}>1, then \code{progress} is set to \code{FALSE} by
 default, as it is not possible to display progress bars for parallel
 processes at the current time.}
+
+\item{safe.boot}{logical: should each bootstrap replication be wrapped in a \code{\link[base]{tryCatch}} statement to catch errors (e.g. during the optimisation progress)? When model fitting throws errors, a new bootstrap sample is drawn for the current iteration and the model is re-fit; this process continue until a model fits succesfully. Default is \code{FALSE}.}
 
 \item{...}{options passed to the \code{control} argument.}
 }


### PR DESCRIPTION
Hi!
I was getting some errors computing boostrapped standard errors using `bootSE()` (I guess from "bad" boostrap samples), hence I added the option to catch errors using `tryCatch()` and repeating a bootstrap iteration until a model fits (with or without converging) with no errors.

Alessandro